### PR TITLE
[Feat] 친한 친구 설정/해제 및 친한 친구 목록 구현

### DIFF
--- a/src/main/java/com/kuit/chozy/common/exception/ErrorCode.java
+++ b/src/main/java/com/kuit/chozy/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     SELF_BLOCK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, 4004, "자기 자신은 차단할 수 없습니다."),
     SELF_UNBLOCK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, 4006, "자기 자신에 대한 차단은 해제할 수 없습니다."),
     ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, 4005, "이미 차단한 사용자입니다."),
+    SELF_CLOSE_FRIEND_NOT_ALLOWED(HttpStatus.BAD_REQUEST,4007, "자기 자신은 친한 친구로 설정할 수 없습니다."),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 4012, "인증이 필요합니다."),
@@ -25,6 +26,7 @@ public enum ErrorCode {
     CANNOT_FOLLOW_BLOCKED_USER(HttpStatus.CONFLICT, 4095, "차단한 사용자는 팔로우할 수 없습니다."),
     ALREADY_FOLLOWING(HttpStatus.CONFLICT, 4096, "이미 팔로우한 사용자입니다."),
     ALREADY_REQUESTED(HttpStatus.CONFLICT, 4098, "이미 팔로우 요청을 보낸 사용자입니다."),
+    BLOCK_RELATION_EXISTS(HttpStatus.CONFLICT,4097, "차단 관계가 존재하여 요청을 처리할 수 없습니다."),
 
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/com/kuit/chozy/userrelation/controller/CloseFriendController.java
+++ b/src/main/java/com/kuit/chozy/userrelation/controller/CloseFriendController.java
@@ -1,0 +1,59 @@
+package com.kuit.chozy.userrelation.controller;
+
+import com.kuit.chozy.common.response.ApiResponse;
+import com.kuit.chozy.userrelation.dto.response.CloseFriendListResponse;
+import com.kuit.chozy.userrelation.dto.response.CloseFriendSetResponse;
+import com.kuit.chozy.userrelation.dto.response.CloseFriendUnsetResponse;
+import com.kuit.chozy.userrelation.service.CloseFriendService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users/me/close-friends")
+public class CloseFriendController {
+
+    private final CloseFriendService closeFriendService;
+
+    public CloseFriendController(CloseFriendService closeFriendService) {
+        this.closeFriendService = closeFriendService;
+    }
+
+    @PostMapping("/{targetUserId}")
+    public ApiResponse<CloseFriendSetResponse> setCloseFriend(
+            @PathVariable Long targetUserId
+            // 여기에 meId 주입
+            // 예: @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        // TODO: accessToken 기반으로 meId 추출
+        // Long meId = userDetails.getUserId();
+        Long meId = 1L;
+
+        CloseFriendSetResponse result = closeFriendService.setCloseFriend(meId, targetUserId);
+        return ApiResponse.success(result);
+    }
+
+    @DeleteMapping("/{targetUserId}")
+    public ApiResponse<CloseFriendUnsetResponse> unsetCloseFriend(
+            @PathVariable Long targetUserId
+    ) {
+        // Long meId = userDetails.getUserId();
+        // TODO: accessToken 기반으로 meId 추출
+        Long meId = 1L;
+
+        CloseFriendUnsetResponse result = closeFriendService.unsetCloseFriend(meId, targetUserId);
+        return ApiResponse.success(result);
+    }
+
+    @GetMapping
+    public ApiResponse<CloseFriendListResponse> getCloseFriends(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+            // TODO: accessToken 기반으로 meId 추출
+    ) {
+        // Long meId = userDetails.getUserId();
+        Long meId = 1L;
+
+        CloseFriendListResponse result = closeFriendService.getCloseFriends(meId, page, size);
+        return ApiResponse.success(result);
+    }
+
+}

--- a/src/main/java/com/kuit/chozy/userrelation/domain/CloseFriend.java
+++ b/src/main/java/com/kuit/chozy/userrelation/domain/CloseFriend.java
@@ -1,0 +1,52 @@
+package com.kuit.chozy.userrelation.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "close_friend",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_close_friend_user_target", columnNames = {"user_id", "target_user_id"})
+        }
+)
+public class CloseFriend {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "target_user_id", nullable = false)
+    private Long targetUserId;
+
+    @Column(name = "set_at", nullable = false)
+    private LocalDateTime setAt;
+
+    protected CloseFriend() {
+    }
+
+    public CloseFriend(Long userId, Long targetUserId, LocalDateTime setAt) {
+        this.userId = userId;
+        this.targetUserId = targetUserId;
+        this.setAt = setAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Long getTargetUserId() {
+        return targetUserId;
+    }
+
+    public LocalDateTime getSetAt() {
+        return setAt;
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/dto/response/CloseFriendItemResponse.java
+++ b/src/main/java/com/kuit/chozy/userrelation/dto/response/CloseFriendItemResponse.java
@@ -1,0 +1,56 @@
+package com.kuit.chozy.userrelation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+
+public class CloseFriendItemResponse {
+
+    private Long userId;
+    private String loginId;
+    private String nickname;
+    private String profileImageUrl;
+    private boolean isAccountPublic;
+    private LocalDateTime setAt;
+
+    public CloseFriendItemResponse(
+            Long userId,
+            String loginId,
+            String nickname,
+            String profileImageUrl,
+            boolean isAccountPublic,
+            LocalDateTime setAt
+    ) {
+        this.userId = userId;
+        this.loginId = loginId;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.isAccountPublic = isAccountPublic;
+        this.setAt = setAt;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getLoginId() {
+        return loginId;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    @JsonProperty("isAccountPublic")
+    public boolean isAccountPublic() {
+        return isAccountPublic;
+    }
+
+    public LocalDateTime getSetAt() {
+        return setAt;
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/dto/response/CloseFriendListResponse.java
+++ b/src/main/java/com/kuit/chozy/userrelation/dto/response/CloseFriendListResponse.java
@@ -1,0 +1,53 @@
+package com.kuit.chozy.userrelation.dto.response;
+
+import java.util.List;
+
+public class CloseFriendListResponse {
+
+    private List<CloseFriendItemResponse> items;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+
+    public CloseFriendListResponse(
+            List<CloseFriendItemResponse> items,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages,
+            boolean hasNext
+    ) {
+        this.items = items;
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.hasNext = hasNext;
+    }
+
+    public List<CloseFriendItemResponse> getItems() {
+        return items;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public long getTotalElements() {
+        return totalElements;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public boolean isHasNext() {
+        return hasNext;
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/dto/response/CloseFriendSetResponse.java
+++ b/src/main/java/com/kuit/chozy/userrelation/dto/response/CloseFriendSetResponse.java
@@ -1,0 +1,31 @@
+package com.kuit.chozy.userrelation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+
+public class CloseFriendSetResponse {
+
+    private Long targetUserId;
+    private boolean isCloseFriend;
+    private LocalDateTime setAt;
+
+    public CloseFriendSetResponse(Long targetUserId, boolean isCloseFriend, LocalDateTime setAt) {
+        this.targetUserId = targetUserId;
+        this.isCloseFriend = isCloseFriend;
+        this.setAt = setAt;
+    }
+
+    public Long getTargetUserId() {
+        return targetUserId;
+    }
+
+    @JsonProperty("isCloseFriend")
+    public boolean isCloseFriend() {
+        return isCloseFriend;
+    }
+
+    public LocalDateTime getSetAt() {
+        return setAt;
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/dto/response/CloseFriendUnsetResponse.java
+++ b/src/main/java/com/kuit/chozy/userrelation/dto/response/CloseFriendUnsetResponse.java
@@ -1,0 +1,31 @@
+package com.kuit.chozy.userrelation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+
+public class CloseFriendUnsetResponse {
+
+    private Long targetUserId;
+    private boolean isCloseFriend;
+    private LocalDateTime unsetAt;
+
+    public CloseFriendUnsetResponse(Long targetUserId, boolean isCloseFriend, LocalDateTime unsetAt) {
+        this.targetUserId = targetUserId;
+        this.isCloseFriend = isCloseFriend;
+        this.unsetAt = unsetAt;
+    }
+
+    public Long getTargetUserId() {
+        return targetUserId;
+    }
+
+    @JsonProperty("isCloseFriend")
+    public boolean isCloseFriend() {
+        return isCloseFriend;
+    }
+
+    public LocalDateTime getUnsetAt() {
+        return unsetAt;
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/repository/CloseFriendRepository.java
+++ b/src/main/java/com/kuit/chozy/userrelation/repository/CloseFriendRepository.java
@@ -1,0 +1,36 @@
+package com.kuit.chozy.userrelation.repository;
+
+import com.kuit.chozy.userrelation.domain.CloseFriend;
+import com.kuit.chozy.userrelation.dto.response.CloseFriendItemResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CloseFriendRepository extends JpaRepository<CloseFriend, Long> {
+
+    boolean existsByUserIdAndTargetUserId(Long userId, Long targetUserId);
+
+    Optional<CloseFriend> findByUserIdAndTargetUserId(Long userId, Long targetUserId);
+
+    void deleteByUserIdAndTargetUserId(Long userId, Long targetUserId);
+
+    @Query("""
+            select new com.kuit.chozy.userrelation.dto.response.CloseFriendItemResponse(
+                u.id,
+                u.loginId,
+                u.nickname,
+                u.profileImageUrl,
+                u.isAccountPublic,
+                cf.setAt
+            )
+            from CloseFriend cf
+            join User u on u.id = cf.targetUserId
+            where cf.userId = :meUserId
+            order by cf.setAt desc
+            """)
+    Page<CloseFriendItemResponse> findCloseFriendItems(@Param("meUserId") Long meUserId, Pageable pageable);
+}

--- a/src/main/java/com/kuit/chozy/userrelation/service/CloseFriendService.java
+++ b/src/main/java/com/kuit/chozy/userrelation/service/CloseFriendService.java
@@ -1,0 +1,134 @@
+package com.kuit.chozy.userrelation.service;
+
+import com.kuit.chozy.common.exception.ApiException;
+import com.kuit.chozy.common.exception.ErrorCode;
+import com.kuit.chozy.user.domain.User;
+import com.kuit.chozy.user.repository.UserRepository;
+import com.kuit.chozy.userrelation.domain.CloseFriend;
+import com.kuit.chozy.userrelation.dto.response.CloseFriendItemResponse;
+import com.kuit.chozy.userrelation.dto.response.CloseFriendListResponse;
+import com.kuit.chozy.userrelation.dto.response.CloseFriendSetResponse;
+import com.kuit.chozy.userrelation.dto.response.CloseFriendUnsetResponse;
+import com.kuit.chozy.userrelation.repository.BlockRepository;
+import com.kuit.chozy.userrelation.repository.CloseFriendRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class CloseFriendService {
+
+    private final CloseFriendRepository closeFriendRepository;
+    private final UserRepository userRepository;
+    private final BlockRepository blockRepository;
+
+    public CloseFriendService(
+            CloseFriendRepository closeFriendRepository,
+            UserRepository userRepository,
+            BlockRepository blockRepository
+    ) {
+        this.closeFriendRepository = closeFriendRepository;
+        this.userRepository = userRepository;
+        this.blockRepository = blockRepository;
+    }
+
+    @Transactional
+    public CloseFriendUnsetResponse unsetCloseFriend(Long meUserId, Long targetUserId) {
+
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new ApiException(ErrorCode.TARGET_USER_NOT_FOUND));
+
+        // 비활성화 계정 체크가 필요하면 추가
+        // if (targetUser.getStatus() == UserStatus.INACTIVE) throw new ApiException(ErrorCode.USER_INACTIVE);
+
+        // 차단 관계 존재 여부 (양방향, active=true)
+        boolean blocked =
+                blockRepository.existsByBlockerIdAndBlockedIdAndActiveTrue(meUserId, targetUserId)
+                        || blockRepository.existsByBlockerIdAndBlockedIdAndActiveTrue(targetUserId, meUserId);
+
+        if (blocked) {
+            throw new ApiException(ErrorCode.BLOCK_RELATION_EXISTS);
+        }
+
+        // 멱등 처리: 있으면 삭제, 없으면 그냥 성공
+        closeFriendRepository.findByUserIdAndTargetUserId(meUserId, targetUserId)
+                .ifPresent(existing -> closeFriendRepository.delete(existing));
+        // 또는:
+        // closeFriendRepository.deleteByUserIdAndTargetUserId(meUserId, targetUserId);
+
+        return new CloseFriendUnsetResponse(
+                targetUserId,
+                false,
+                LocalDateTime.now()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public CloseFriendListResponse getCloseFriends(Long meUserId, int page, int size) {
+        int safePage = Math.max(page, 0);
+        int safeSize = Math.max(1, Math.min(size, 50));
+
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+        Page<CloseFriendItemResponse> result = closeFriendRepository.findCloseFriendItems(meUserId, pageable);
+
+        return new CloseFriendListResponse(
+                result.getContent(),
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.hasNext()
+        );
+    }
+
+
+    @Transactional
+    public CloseFriendSetResponse setCloseFriend(Long meUserId, Long targetUserId) {
+
+        // 자기 자신 설정 불가
+        if (meUserId.equals(targetUserId)) {
+            throw new ApiException(ErrorCode.SELF_CLOSE_FRIEND_NOT_ALLOWED);
+        }
+
+        // 대상 사용자 존재 여부
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new ApiException(ErrorCode.TARGET_USER_NOT_FOUND));
+
+        // 비활성화 계정 체크 (UserStatus 사용 중이면 여기서)
+        // if (targetUser.getStatus() == UserStatus.INACTIVE) {
+        //     throw new ApiException(ErrorCode.USER_INACTIVE);
+        // }
+
+        // 차단 관계 존재 여부 (양방향, active = true)
+        boolean blocked =
+                blockRepository.existsByBlockerIdAndBlockedIdAndActiveTrue(meUserId, targetUserId)
+                        || blockRepository.existsByBlockerIdAndBlockedIdAndActiveTrue(targetUserId, meUserId);
+
+        if (blocked) {
+            throw new ApiException(ErrorCode.BLOCK_RELATION_EXISTS);
+        }
+
+        // 이미 친한 친구면 멱등 성공 처리
+        return closeFriendRepository.findByUserIdAndTargetUserId(meUserId, targetUserId)
+                .map(existing -> new CloseFriendSetResponse(
+                        existing.getTargetUserId(),
+                        true,
+                        existing.getSetAt()
+                ))
+                .orElseGet(() -> {
+                    LocalDateTime now = LocalDateTime.now();
+                    CloseFriend saved =
+                            closeFriendRepository.save(new CloseFriend(meUserId, targetUserId, now));
+
+                    return new CloseFriendSetResponse(
+                            saved.getTargetUserId(),
+                            true,
+                            saved.getSetAt()
+                    );
+                });
+    }
+}


### PR DESCRIPTION
## 🌠 관련 이슈
closes #6

## 🌠 주요 변경 사항

- 친한 친구 설정 API 구현 (POST /users/me/close-friends/{targetUserId})
- 친한 친구 해제 API 구현 (DELETE /users/me/close-friends/{targetUserId})
- 친한 친구 목록 조회 API 구현 (GET /users/me/close-friends)
- 차단 관계 존재 시 친한 친구 설정/해제 불가 처리 (4097)
- 자기 자신을 친한 친구로 설정하는 경우 예외 처리 (4007)

## 🌠 기타 작업
- Postman을 통한 API 동작 검증

## 🌠 미구현된 내용