### PR TITLE
[Feat] Follow request 처리 및 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/kuit/chozy/common/exception/ErrorCode.java
+++ b/src/main/java/com/kuit/chozy/common/exception/ErrorCode.java
@@ -11,22 +11,26 @@ public enum ErrorCode {
     SELF_UNBLOCK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, 4006, "자기 자신에 대한 차단은 해제할 수 없습니다."),
     ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, 4005, "이미 차단한 사용자입니다."),
     SELF_CLOSE_FRIEND_NOT_ALLOWED(HttpStatus.BAD_REQUEST,4007, "자기 자신은 친한 친구로 설정할 수 없습니다."),
+    INVALID_REQUEST_VALUE(HttpStatus.BAD_REQUEST,4001, "요청 값이 올바르지 않습니다."),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 4012, "인증이 필요합니다."),
 
     // 403
     DEACTIVATED_ACCOUNT(HttpStatus.FORBIDDEN, 4030, "비활성화된 계정입니다."),
+    FOLLOW_REQUEST_FORBIDDEN(HttpStatus.FORBIDDEN,4032, "해당 팔로우 요청을 처리할 권한이 없습니다."),
 
     // 404
     TARGET_USER_NOT_FOUND(HttpStatus.NOT_FOUND, 4041, "대상 사용자를 찾을 수 없습니다."),
     NOT_BLOCKED(HttpStatus.NOT_FOUND, 4042, "차단 상태가 아닙니다."),
+    FOLLOW_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND,4042, "팔로우 요청을 찾을 수 없습니다."),
 
     // 409
     CANNOT_FOLLOW_BLOCKED_USER(HttpStatus.CONFLICT, 4095, "차단한 사용자는 팔로우할 수 없습니다."),
     ALREADY_FOLLOWING(HttpStatus.CONFLICT, 4096, "이미 팔로우한 사용자입니다."),
     ALREADY_REQUESTED(HttpStatus.CONFLICT, 4098, "이미 팔로우 요청을 보낸 사용자입니다."),
     BLOCK_RELATION_EXISTS(HttpStatus.CONFLICT,4097, "차단 관계가 존재하여 요청을 처리할 수 없습니다."),
+    FOLLOW_REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT,4092, "이미 처리된 팔로우 요청입니다."),
 
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/com/kuit/chozy/userrelation/controller/FollowRequestController.java
+++ b/src/main/java/com/kuit/chozy/userrelation/controller/FollowRequestController.java
@@ -1,0 +1,44 @@
+package com.kuit.chozy.userrelation.controller;
+
+import com.kuit.chozy.common.response.ApiResponse;
+import com.kuit.chozy.userrelation.dto.request.FollowRequestProcessRequest;
+import com.kuit.chozy.userrelation.dto.response.FollowRequestListResponse;
+import com.kuit.chozy.userrelation.dto.response.FollowRequestProcessResponse;
+import com.kuit.chozy.userrelation.service.FollowRequestService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class FollowRequestController {
+
+    private final FollowRequestService followRequestService;
+
+    public FollowRequestController(FollowRequestService followRequestService) {
+        this.followRequestService = followRequestService;
+    }
+
+    @PatchMapping("/users/follow-requests/{requestId}")
+    public ApiResponse<FollowRequestProcessResponse> process(
+            @PathVariable Long requestId,
+            @RequestBody FollowRequestProcessRequest request
+            // meUserId 주입: 프로젝트 인증 방식으로 교체
+    ) {
+        Long meUserId = 1L; // TODO: 인증 연동
+
+        FollowRequestProcessResponse result =
+                followRequestService.process(meUserId, requestId, request.getStatus());
+
+        return ApiResponse.success(result);
+    }
+
+    @GetMapping("/users/me/follow-requests")
+    public ApiResponse<FollowRequestListResponse> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+            // meUserId 주입: 프로젝트 인증 방식으로 교체
+    ) {
+        Long meUserId = 1L; // TODO: 인증 연동
+
+        FollowRequestListResponse result = followRequestService.getMyPendingRequests(meUserId, page, size);
+        return ApiResponse.success(result);
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/domain/FollowRequest.java
+++ b/src/main/java/com/kuit/chozy/userrelation/domain/FollowRequest.java
@@ -24,6 +24,9 @@ public class FollowRequest {
     @Column(name = "requested_at", nullable = false)
     private LocalDateTime requestedAt;
 
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
     protected FollowRequest() {
     }
 
@@ -32,6 +35,7 @@ public class FollowRequest {
         this.targetId = targetId;
         this.status = status;
         this.requestedAt = requestedAt;
+        this.processedAt = processedAt;
     }
 
     public Long getId() {
@@ -57,4 +61,19 @@ public class FollowRequest {
     public void changeStatus(FollowRequestStatus status) {
         this.status = status;
     }
+
+    public boolean isPending() {
+        return this.status == FollowRequestStatus.PENDING;
+    }
+
+    public void accept(LocalDateTime processedAt) {
+        this.status = FollowRequestStatus.ACCEPTED;
+        this.processedAt = processedAt;
+    }
+
+    public void reject(LocalDateTime processedAt) {
+        this.status = FollowRequestStatus.REJECTED;
+        this.processedAt = processedAt;
+    }
+
 }

--- a/src/main/java/com/kuit/chozy/userrelation/dto/request/FollowRequestProcessRequest.java
+++ b/src/main/java/com/kuit/chozy/userrelation/dto/request/FollowRequestProcessRequest.java
@@ -1,0 +1,22 @@
+package com.kuit.chozy.userrelation.dto.request;
+
+public class FollowRequestProcessRequest {
+
+    private ProcessStatus status;
+
+    protected FollowRequestProcessRequest() {
+    }
+
+    public FollowRequestProcessRequest(ProcessStatus status) {
+        this.status = status;
+    }
+
+    public ProcessStatus getStatus() {
+        return status;
+    }
+
+    public enum ProcessStatus {
+        ACCEPT,
+        REJECT
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/dto/response/FollowRequestFromUserResponse.java
+++ b/src/main/java/com/kuit/chozy/userrelation/dto/response/FollowRequestFromUserResponse.java
@@ -1,0 +1,32 @@
+package com.kuit.chozy.userrelation.dto.response;
+
+public class FollowRequestFromUserResponse {
+
+    private Long userId;
+    private String loginId;
+    private String nickname;
+    private String profileImageUrl;
+
+    public FollowRequestFromUserResponse(Long userId, String loginId, String nickname, String profileImageUrl) {
+        this.userId = userId;
+        this.loginId = loginId;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getLoginId() {
+        return loginId;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/dto/response/FollowRequestListItemResponse.java
+++ b/src/main/java/com/kuit/chozy/userrelation/dto/response/FollowRequestListItemResponse.java
@@ -1,0 +1,28 @@
+package com.kuit.chozy.userrelation.dto.response;
+
+import java.time.LocalDateTime;
+
+public class FollowRequestListItemResponse {
+
+    private Long requestId;
+    private FollowRequestFromUserResponse fromUser;
+    private LocalDateTime requestedAt;
+
+    public FollowRequestListItemResponse(Long requestId, FollowRequestFromUserResponse fromUser, LocalDateTime requestedAt) {
+        this.requestId = requestId;
+        this.fromUser = fromUser;
+        this.requestedAt = requestedAt;
+    }
+
+    public Long getRequestId() {
+        return requestId;
+    }
+
+    public FollowRequestFromUserResponse getFromUser() {
+        return fromUser;
+    }
+
+    public LocalDateTime getRequestedAt() {
+        return requestedAt;
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/dto/response/FollowRequestListResponse.java
+++ b/src/main/java/com/kuit/chozy/userrelation/dto/response/FollowRequestListResponse.java
@@ -1,0 +1,53 @@
+package com.kuit.chozy.userrelation.dto.response;
+
+import java.util.List;
+
+public class FollowRequestListResponse {
+
+    private List<FollowRequestListItemResponse> items;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+
+    public FollowRequestListResponse(
+            List<FollowRequestListItemResponse> items,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages,
+            boolean hasNext
+    ) {
+        this.items = items;
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.hasNext = hasNext;
+    }
+
+    public List<FollowRequestListItemResponse> getItems() {
+        return items;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public long getTotalElements() {
+        return totalElements;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public boolean isHasNext() {
+        return hasNext;
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/dto/response/FollowRequestProcessResponse.java
+++ b/src/main/java/com/kuit/chozy/userrelation/dto/response/FollowRequestProcessResponse.java
@@ -1,0 +1,76 @@
+package com.kuit.chozy.userrelation.dto.response;
+
+import java.time.LocalDateTime;
+
+public class FollowRequestProcessResponse {
+
+    private Long requestId;
+    private String status; // "ACCEPTED" | "REJECTED"
+    private LocalDateTime processedAt;
+    private Long fromUserId;
+    private Long toUserId;
+
+    public FollowRequestProcessResponse(
+            Long requestId,
+            String status,
+            LocalDateTime processedAt,
+            Long fromUserId,
+            Long toUserId
+    ) {
+        this.requestId = requestId;
+        this.status = status;
+        this.processedAt = processedAt;
+        this.fromUserId = fromUserId;
+        this.toUserId = toUserId;
+    }
+
+    public Long getRequestId() {
+        return requestId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public LocalDateTime getProcessedAt() {
+        return processedAt;
+    }
+
+    public Long getFromUserId() {
+        return fromUserId;
+    }
+
+    public Long getToUserId() {
+        return toUserId;
+    }
+
+    public static FollowRequestProcessResponse accepted(
+            Long requestId,
+            LocalDateTime processedAt,
+            Long fromUserId,
+            Long toUserId
+    ) {
+        return new FollowRequestProcessResponse(
+                requestId,
+                "ACCEPTED",
+                processedAt,
+                fromUserId,
+                toUserId
+        );
+    }
+
+    public static FollowRequestProcessResponse rejected(
+            Long requestId,
+            LocalDateTime processedAt,
+            Long fromUserId,
+            Long toUserId
+    ) {
+        return new FollowRequestProcessResponse(
+                requestId,
+                "REJECTED",
+                processedAt,
+                fromUserId,
+                toUserId
+        );
+    }
+}

--- a/src/main/java/com/kuit/chozy/userrelation/repository/FollowRequestRepository.java
+++ b/src/main/java/com/kuit/chozy/userrelation/repository/FollowRequestRepository.java
@@ -2,6 +2,9 @@ package com.kuit.chozy.userrelation.repository;
 
 import com.kuit.chozy.userrelation.domain.FollowRequest;
 import com.kuit.chozy.userrelation.domain.FollowRequestStatus;
+import com.kuit.chozy.userrelation.dto.response.FollowRequestListItemResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -50,4 +53,20 @@ public interface FollowRequestRepository extends JpaRepository<FollowRequest, Lo
     """)
     int deletePendingBetween(@Param("meId") Long meId,
                              @Param("targetUserId") Long targetUserId);
+
+    @Query("""
+        select new com.kuit.chozy.userrelation.dto.response.FollowRequestListItemResponse(
+            fr.id,
+            new com.kuit.chozy.userrelation.dto.response.FollowRequestFromUserResponse(
+                u.id, u.loginId, u.nickname, u.profileImageUrl
+            ),
+            fr.requestedAt
+        )
+        from FollowRequest fr
+        join User u on u.id = fr.requesterId
+        where fr.targetId = :meUserId
+          and fr.status = 'PENDING'
+        order by fr.requestedAt desc
+        """)
+    Page<FollowRequestListItemResponse> findMyPendingRequests(@Param("meUserId") Long meUserId, Pageable pageable);
 }

--- a/src/main/java/com/kuit/chozy/userrelation/service/FollowRequestService.java
+++ b/src/main/java/com/kuit/chozy/userrelation/service/FollowRequestService.java
@@ -1,0 +1,123 @@
+package com.kuit.chozy.userrelation.service;
+
+import com.kuit.chozy.common.exception.ApiException;
+import com.kuit.chozy.common.exception.ErrorCode;
+import com.kuit.chozy.userrelation.domain.Follow;
+import com.kuit.chozy.userrelation.domain.FollowRequest;
+import com.kuit.chozy.userrelation.dto.request.FollowRequestProcessRequest;
+import com.kuit.chozy.userrelation.dto.response.FollowRequestListItemResponse;
+import com.kuit.chozy.userrelation.dto.response.FollowRequestListResponse;
+import com.kuit.chozy.userrelation.dto.response.FollowRequestProcessResponse;
+import com.kuit.chozy.userrelation.repository.BlockRepository;
+import com.kuit.chozy.userrelation.repository.FollowRepository;
+import com.kuit.chozy.userrelation.repository.FollowRequestRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class FollowRequestService {
+
+    private final FollowRequestRepository followRequestRepository;
+    private final FollowRepository followRepository;
+    private final BlockRepository blockRepository;
+
+    public FollowRequestService(
+            FollowRequestRepository followRequestRepository,
+            FollowRepository followRepository,
+            BlockRepository blockRepository
+    ) {
+        this.followRequestRepository = followRequestRepository;
+        this.followRepository = followRepository;
+        this.blockRepository = blockRepository;
+    }
+
+    @Transactional
+    public FollowRequestProcessResponse process(
+            Long meUserId,
+            Long requestId,
+            FollowRequestProcessRequest.ProcessStatus action
+    ) {
+
+        FollowRequest request = followRequestRepository.findById(requestId)
+                .orElseThrow(() -> new ApiException(ErrorCode.FOLLOW_REQUEST_NOT_FOUND));
+
+        // 내가 받은 요청인지 검증 (targetId = me)
+        if (!request.getTargetId().equals(meUserId)) {
+            throw new ApiException(ErrorCode.FOLLOW_REQUEST_FORBIDDEN);
+        }
+
+        // 이미 처리된 요청인지 검증
+        if (!request.isPending()) {
+            throw new ApiException(ErrorCode.FOLLOW_REQUEST_ALREADY_PROCESSED);
+        }
+
+        // 차단 관계 존재 여부 (양방향, active=true)
+        boolean blocked =
+                blockRepository.existsByBlockerIdAndBlockedIdAndActiveTrue(
+                        meUserId, request.getRequesterId())
+                        || blockRepository.existsByBlockerIdAndBlockedIdAndActiveTrue(
+                        request.getRequesterId(), meUserId);
+
+        if (blocked) {
+            throw new ApiException(ErrorCode.BLOCK_RELATION_EXISTS);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (action == FollowRequestProcessRequest.ProcessStatus.ACCEPT) {
+            request.accept(now);
+
+            // Follow 생성 (requester -> target)
+            followRepository.save(
+                    new Follow(
+                            request.getRequesterId(),
+                            request.getTargetId(),
+                            now
+                    )
+            );
+
+            return FollowRequestProcessResponse.accepted(
+                    request.getId(),
+                    now,
+                    request.getRequesterId(),
+                    request.getTargetId()
+            );
+        }
+
+        // REJECT
+        request.reject(now);
+
+        return FollowRequestProcessResponse.rejected(
+                request.getId(),
+                now,
+                request.getRequesterId(),
+                request.getTargetId()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public FollowRequestListResponse getMyPendingRequests(Long meUserId, int page, int size) {
+
+        // page / size 검증
+        if (page < 0 || size <= 0 || size > 50) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST_VALUE);
+        }
+
+        PageRequest pageable = PageRequest.of(page, size);
+        Page<FollowRequestListItemResponse> result =
+                followRequestRepository.findMyPendingRequests(meUserId, pageable);
+
+        return new FollowRequestListResponse(
+                result.getContent(),
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.hasNext()
+        );
+    }
+}


### PR DESCRIPTION
## 🌠 관련 이슈
- closes #8

## 🌠 주요 변경 사항
- 팔로우 요청 수락/거절 API 구현
- 팔로우 요청 목록 조회 API 구현 (PENDING 대상, 페이징)
- ACCEPT 시 Follow 관계 생성
- 차단 관계 존재 시 요청 처리 불가(4097)
- 이미 처리된 요청 재처리 방지

## 🌠 기타 작업
- FollowRequest 도메인 메서드 정리 (accept / reject)
- Postman 테스트 완료

## 🌠 미구현된 내용