### PR TITLE
[Feat] home 검색 기능 구현

### DIFF
--- a/src/main/java/com/kuit/chozy/ChozyApplication.java
+++ b/src/main/java/com/kuit/chozy/ChozyApplication.java
@@ -2,8 +2,10 @@ package com.kuit.chozy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ChozyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kuit/chozy/home/controller/HomeSearchController.java
+++ b/src/main/java/com/kuit/chozy/home/controller/HomeSearchController.java
@@ -1,0 +1,59 @@
+package com.kuit.chozy.home.controller;
+
+import com.kuit.chozy.common.response.ApiResponse;
+import com.kuit.chozy.home.dto.request.SaveSearchKeywordRequest;
+import com.kuit.chozy.home.dto.response.PopularSearchKeywordResponse;
+import com.kuit.chozy.home.dto.response.RecentSearchKeywordResponse;
+import com.kuit.chozy.home.dto.response.RecommendSearchKeywordResponse;
+import com.kuit.chozy.home.service.HomeSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/home/search")
+@RequiredArgsConstructor
+public class HomeSearchController {
+
+    private final HomeSearchService homeSearchService;
+
+    // 최근 검색어 조회
+    @GetMapping("/recent")
+    public ApiResponse<RecentSearchKeywordResponse> getRecentSearchKeyword(
+            //TODO: 로그인 기능 생기면 변경
+            @RequestHeader("X-USER-ID") Long userId
+    ){
+        return ApiResponse.success(homeSearchService.getRecentSearchKeyword(userId));
+    }
+
+    // 인기 검색어 조회
+    @GetMapping("/popular")
+    public ApiResponse<List<PopularSearchKeywordResponse>> getPopularSearchKeyword(){
+        return ApiResponse.success(homeSearchService.getPopularSearchKeyword());
+    }
+
+    // 검색어 자동 완성
+    @GetMapping("/recommend")
+    public ApiResponse<RecommendSearchKeywordResponse> getRecommendSearchKeyword(
+            @RequestParam String keyword
+    ){
+        return ApiResponse.success(homeSearchService.getRecommendSearchKeyword(keyword));
+    }
+
+    // 검색어 저장
+    @PostMapping
+    public ApiResponse<Void> saveSearchKeyword(
+            @RequestHeader("X-USER-ID") Long userId,
+            @RequestBody SaveSearchKeywordRequest request
+    ){
+        System.out.println("### saveSearchKeyword called ###");
+        System.out.println("userId=" + userId + ", keyword=" + request.keyword());
+
+        if (request == null || request.keyword() == null || request.keyword().isBlank()) {
+            throw new IllegalArgumentException("keyword is required");
+        }
+        homeSearchService.saveSearchKeyword(userId, request.keyword());
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/kuit/chozy/home/dto/request/SaveSearchKeywordRequest.java
+++ b/src/main/java/com/kuit/chozy/home/dto/request/SaveSearchKeywordRequest.java
@@ -1,0 +1,6 @@
+package com.kuit.chozy.home.dto.request;
+
+public record SaveSearchKeywordRequest(
+        String keyword
+) {}
+

--- a/src/main/java/com/kuit/chozy/home/dto/response/KeywordResponse.java
+++ b/src/main/java/com/kuit/chozy/home/dto/response/KeywordResponse.java
@@ -1,0 +1,6 @@
+package com.kuit.chozy.home.dto.response;
+
+public record KeywordResponse(
+        Long keywordId,
+        String keyword
+) {}

--- a/src/main/java/com/kuit/chozy/home/dto/response/PopularSearchKeywordResponse.java
+++ b/src/main/java/com/kuit/chozy/home/dto/response/PopularSearchKeywordResponse.java
@@ -1,0 +1,14 @@
+package com.kuit.chozy.home.dto.response;
+
+import com.kuit.chozy.home.entity.TrendingCount;
+
+public record PopularSearchKeywordResponse(
+        Long keywordId,
+        String keyword,
+        int previousRank,
+        int currentRank
+) {
+    public static PopularSearchKeywordResponse from(TrendingCount trendingCount) {
+        return new PopularSearchKeywordResponse(trendingCount.getId(), trendingCount.getKeyword(), trendingCount.getRankYesterday(), trendingCount.getRankToday());
+    }
+}

--- a/src/main/java/com/kuit/chozy/home/dto/response/RecentSearchKeywordResponse.java
+++ b/src/main/java/com/kuit/chozy/home/dto/response/RecentSearchKeywordResponse.java
@@ -1,0 +1,7 @@
+package com.kuit.chozy.home.dto.response;
+
+import java.util.List;
+
+public record RecentSearchKeywordResponse(
+       List<KeywordResponse> keywords
+) {}

--- a/src/main/java/com/kuit/chozy/home/dto/response/RecommendSearchKeywordResponse.java
+++ b/src/main/java/com/kuit/chozy/home/dto/response/RecommendSearchKeywordResponse.java
@@ -1,0 +1,7 @@
+package com.kuit.chozy.home.dto.response;
+
+import java.util.List;
+
+public record RecommendSearchKeywordResponse(
+        List<KeywordResponse> keywords
+) {}

--- a/src/main/java/com/kuit/chozy/home/entity/SearchHistory.java
+++ b/src/main/java/com/kuit/chozy/home/entity/SearchHistory.java
@@ -1,0 +1,84 @@
+package com.kuit.chozy.home.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "search_histories",
+        indexes = {
+                @Index(name = "idx_search_histories_user", columnList = "user_id"),
+                @Index(name = "idx_search_histories_keyword", columnList = "keyword")
+        }
+)
+public class SearchHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 사용자 ID (User 엔티티가 있다면 ManyToOne으로 변경 가능) */
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    /** 검색 키워드 */
+    @Column(nullable = false, length = 100)
+    private String keyword;
+
+    /** 특정 기간 내 검색 횟수 */
+    @Column(name = "count_in_period", nullable = false)
+    private int countInPeriod;
+
+    /** 누적 검색 횟수 */
+    @Column(name = "count_total", nullable = false)
+    private int countTotal;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SearchStatus status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /* ===== 생성 메서드 ===== */
+    public static SearchHistory create(Long userId, String keyword) {
+        SearchHistory history = new SearchHistory();
+        history.userId = userId;
+        history.keyword = keyword;
+        history.countInPeriod = 1;
+        history.countTotal = 1;
+        history.status = SearchStatus.ACTIVE;
+        return history;
+    }
+
+    /* ===== 도메인 메서드 ===== */
+    public void increaseCount() {
+        this.countInPeriod++;
+        this.countTotal++;
+    }
+
+    public void resetPeriodCount() {
+        this.countInPeriod = 0;
+    }
+
+    public void deactivate() {
+        this.status = SearchStatus.INACTIVE;
+    }
+
+    public void delete() {
+        this.status = SearchStatus.DELETED;
+    }
+}

--- a/src/main/java/com/kuit/chozy/home/entity/SearchStatus.java
+++ b/src/main/java/com/kuit/chozy/home/entity/SearchStatus.java
@@ -1,0 +1,7 @@
+package com.kuit.chozy.home.entity;
+
+public enum SearchStatus {
+    ACTIVE,
+    INACTIVE,
+    DELETED
+}

--- a/src/main/java/com/kuit/chozy/home/entity/TrendingCount.java
+++ b/src/main/java/com/kuit/chozy/home/entity/TrendingCount.java
@@ -1,0 +1,96 @@
+package com.kuit.chozy.home.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "trending_count",
+        indexes = {
+                @Index(name = "idx_trending_keyword", columnList = "keyword")
+        }
+)
+public class TrendingCount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 검색 키워드 */
+    @Column(nullable = false, length = 100)
+    private String keyword;
+
+    /** 하루 카운트 */
+    @Column(name = "daily_count", nullable = false)
+    private int dailyCount;
+
+    /** 전날 순위 */
+    @Column(name = "rank_yesterday", nullable = false)
+    private int rankYesterday;
+
+    /** 오늘 순위 */
+    @Column(name = "rank_today", nullable = false)
+    private int rankToday;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SearchStatus status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /* ===== 생성 메서드 ===== */
+    public static TrendingCount create(String keyword, int rankToday) {
+        TrendingCount trending = new TrendingCount();
+        trending.keyword = keyword;
+        trending.dailyCount = 0;
+        trending.rankToday = 0;
+        trending.rankYesterday = 0;
+        trending.status = SearchStatus.ACTIVE;
+        return trending;
+    }
+
+    /* ===== 도메인 메서드 ===== */
+    public void updateRank(int newRank) {
+        this.rankYesterday = this.rankToday;
+        this.rankToday = newRank;
+    }
+
+    public int getRankDiff() {
+        return this.rankYesterday - this.rankToday;
+    }
+
+    public void delete() {
+        this.status = SearchStatus.DELETED;
+    }
+
+    public void moveTodayToYesterday() {
+        this.rankYesterday = this.rankToday;
+    }
+
+    public void setTodayRank(int rank) {
+        this.rankToday = rank;
+    }
+
+    public void resetDailyCount() {
+        this.dailyCount = 0;
+    }
+
+    public void increaseDailyCount() {
+        this.dailyCount++;
+    }
+
+}

--- a/src/main/java/com/kuit/chozy/home/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/kuit/chozy/home/repository/SearchHistoryRepository.java
@@ -1,0 +1,33 @@
+package com.kuit.chozy.home.repository;
+
+import com.kuit.chozy.home.entity.SearchHistory;
+import com.kuit.chozy.home.entity.SearchStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+
+    Optional<SearchHistory> findByUserIdAndKeywordAndStatus(
+            Long userId,
+            String keyword,
+            SearchStatus status
+    );
+
+    List<SearchHistory> findTop10ByUserIdAndStatusOrderByUpdatedAtDesc(
+            Long userId,
+            SearchStatus status
+    );
+
+    List<SearchHistory> findTop10ByStatusAndKeywordContainingOrderByCountTotalDescUpdatedAtDesc(
+            SearchStatus status, String keyword
+    );
+
+}

--- a/src/main/java/com/kuit/chozy/home/repository/TrendingCountRepository.java
+++ b/src/main/java/com/kuit/chozy/home/repository/TrendingCountRepository.java
@@ -1,0 +1,23 @@
+package com.kuit.chozy.home.repository;
+
+import com.kuit.chozy.home.entity.SearchStatus;
+import com.kuit.chozy.home.entity.TrendingCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TrendingCountRepository extends JpaRepository<TrendingCount, Long> {
+
+    List<TrendingCount> findTop10ByStatusOrderByRankTodayAsc(
+            SearchStatus status
+    );
+
+    List<TrendingCount> findByStatus(SearchStatus status);
+
+    List<TrendingCount> findTop10ByStatusOrderByDailyCountDesc(SearchStatus status);
+
+    Optional<TrendingCount> findByKeywordAndStatus(String keyword, SearchStatus searchStatus);
+}

--- a/src/main/java/com/kuit/chozy/home/scheduler/TrendingScheduler.java
+++ b/src/main/java/com/kuit/chozy/home/scheduler/TrendingScheduler.java
@@ -1,0 +1,19 @@
+package com.kuit.chozy.home.scheduler;
+
+import com.kuit.chozy.home.entity.SearchStatus;
+import com.kuit.chozy.home.service.TrendingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TrendingScheduler {
+
+    private final TrendingService trendingService;
+
+    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    public void updateDailyTrending(){
+        trendingService.rebuildDailyTrending();
+    }
+}

--- a/src/main/java/com/kuit/chozy/home/service/HomeSearchService.java
+++ b/src/main/java/com/kuit/chozy/home/service/HomeSearchService.java
@@ -1,0 +1,79 @@
+package com.kuit.chozy.home.service;
+
+import com.kuit.chozy.home.dto.response.KeywordResponse;
+import com.kuit.chozy.home.dto.response.PopularSearchKeywordResponse;
+import com.kuit.chozy.home.dto.response.RecentSearchKeywordResponse;
+import com.kuit.chozy.home.dto.response.RecommendSearchKeywordResponse;
+import com.kuit.chozy.home.entity.SearchHistory;
+import com.kuit.chozy.home.entity.SearchStatus;
+import com.kuit.chozy.home.entity.TrendingCount;
+import com.kuit.chozy.home.repository.SearchHistoryRepository;
+import com.kuit.chozy.home.repository.TrendingCountRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HomeSearchService {
+
+    private final SearchHistoryRepository searchHistoryRepository;
+    private final TrendingCountRepository trendingCountRepository;
+
+    // 최근 검색어 조회 기능
+    public RecentSearchKeywordResponse getRecentSearchKeyword(Long userId){
+        List<KeywordResponse> histories =
+                searchHistoryRepository.findTop10ByUserIdAndStatusOrderByUpdatedAtDesc(
+                        userId,
+                        SearchStatus.ACTIVE
+                )
+                        .stream()
+                        .map(h -> new KeywordResponse(h.getId(), h.getKeyword()))
+                        .toList();
+        return new RecentSearchKeywordResponse(histories);
+    }
+
+    // 인기 검색어 조회 기능
+    public List<PopularSearchKeywordResponse> getPopularSearchKeyword() {
+        return trendingCountRepository.findTop10ByStatusOrderByRankTodayAsc(SearchStatus.ACTIVE)
+                .stream()
+                .map(k -> new PopularSearchKeywordResponse(k.getId(), k.getKeyword(), k.getRankYesterday(), k.getRankToday()))
+                .toList();
+    }
+
+    // 검색어 자동 완성 기능
+    public RecommendSearchKeywordResponse getRecommendSearchKeyword(String keyword) {
+        List<KeywordResponse> keywords =
+                searchHistoryRepository.findTop10ByStatusAndKeywordContainingOrderByCountTotalDescUpdatedAtDesc(
+                        SearchStatus.ACTIVE, keyword
+                )
+                        .stream()
+                        .map(k -> new KeywordResponse(k.getId(), k.getKeyword()))
+                        .toList();
+        return new RecommendSearchKeywordResponse(keywords);
+    }
+
+    // 검색어 저장 기능
+    @Transactional
+    public void saveSearchKeyword(Long userId, String keyword) {
+        String normalizedKeyword = keyword.trim().toLowerCase();
+
+        // SearchHistory 저장
+        SearchHistory history = searchHistoryRepository.findByUserIdAndKeywordAndStatus(
+                userId, keyword, SearchStatus.ACTIVE
+        ).orElseGet(() -> SearchHistory.create(userId, normalizedKeyword));
+
+        history.increaseCount();
+        searchHistoryRepository.save(history);
+
+        // TrendingCount daily_count 증가
+        TrendingCount tc = trendingCountRepository.findByKeywordAndStatus(
+                keyword, SearchStatus.ACTIVE
+        ).orElseGet(() -> TrendingCount.create(keyword, 9999));
+
+        tc.increaseDailyCount();
+        trendingCountRepository.save(tc);
+    }
+}

--- a/src/main/java/com/kuit/chozy/home/service/TrendingService.java
+++ b/src/main/java/com/kuit/chozy/home/service/TrendingService.java
@@ -1,0 +1,41 @@
+package com.kuit.chozy.home.service;
+
+import com.kuit.chozy.home.entity.SearchStatus;
+import com.kuit.chozy.home.entity.TrendingCount;
+import com.kuit.chozy.home.repository.TrendingCountRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TrendingService {
+
+    private final TrendingCountRepository trendingCountRepository;
+
+    @Transactional
+    public void rebuildDailyTrending() {
+        List<TrendingCount> trendingCounts = trendingCountRepository.findByStatus(SearchStatus.ACTIVE);
+
+        for (TrendingCount tc : trendingCounts) {
+            tc.moveTodayToYesterday();
+        }
+
+        List<TrendingCount> topTrendingCounts = trendingCountRepository.findTop10ByStatusOrderByDailyCountDesc(SearchStatus.ACTIVE);
+
+        for (TrendingCount tc : trendingCounts) {
+            tc.setTodayRank(0);
+        }
+
+        for (int i = 0; i <= topTrendingCounts.size(); i++) {
+            topTrendingCounts.get(i).setTodayRank(i+1);
+        }
+
+        for (TrendingCount tc : trendingCounts) {
+            tc.resetDailyCount();
+        }
+
+    }
+}


### PR DESCRIPTION
## 🌠 관련 이슈
#2 
(상품 api까지 마치면 닫을게용)

## 🌠 주요 변경 사항

- GET /home/search/recent
- GET /home/search/popular
- GET /home/search/recommend?keyword={keyword}
- POST /home/search

## 🌠 기타 작업

- ChozyApplication에 @EnableScheduling 추가
- POSTMAN 테스트 완료(인기 검색어는 하루 단위로 해서 한 번 더 확인해봐야 됨)

## 🌠 미구현된 내용