### PR TITLE
[Feat] 피드, 피드 리포스트, 피드 리액션(LIKES), 피드 북마크 추가

### DIFF
--- a/src/main/java/com/kuit/chozy/community/controller/CommunityFeedController.java
+++ b/src/main/java/com/kuit/chozy/community/controller/CommunityFeedController.java
@@ -1,0 +1,40 @@
+package com.kuit.chozy.community.controller;
+
+import com.kuit.chozy.community.dto.response.FeedItemResponse;
+import com.kuit.chozy.community.domain.FeedTab;
+import com.kuit.chozy.community.service.CommunityFeedService;
+import com.kuit.chozy.global.common.auth.UserId;
+import com.kuit.chozy.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/community/feeds")
+@RequiredArgsConstructor
+public class CommunityFeedController {
+
+    private final CommunityFeedService communityFeedService;
+
+    /**
+     * 피드 목록 조회
+     * @param tab RECOMMEND(추천) | FOLLOWING(팔로우)
+     * @param contentType ALL | POST | REVIEW
+     * @param search 검색어 (선택)
+     * @param page 페이지 (기본 0)
+     * @param size 크기 (기본 20, 최대 50)
+     */
+    @GetMapping
+    public ApiResponse<List<FeedItemResponse>> getFeeds(
+            @UserId Long userId,
+            @RequestParam(defaultValue = "RECOMMEND") FeedTab tab,
+            @RequestParam(defaultValue = "ALL") String contentType,
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        List<FeedItemResponse> result = communityFeedService.getFeeds(userId, tab, contentType, search, page, size);
+        return ApiResponse.success(result);
+    }
+}

--- a/src/main/java/com/kuit/chozy/community/domain/CommunitySearchHistory.java
+++ b/src/main/java/com/kuit/chozy/community/domain/CommunitySearchHistory.java
@@ -1,4 +1,4 @@
-package com.kuit.chozy.community.entity;
+package com.kuit.chozy.community.domain;
 
 import com.kuit.chozy.home.entity.SearchStatus;
 import jakarta.persistence.*;

--- a/src/main/java/com/kuit/chozy/community/domain/Feed.java
+++ b/src/main/java/com/kuit/chozy/community/domain/Feed.java
@@ -1,0 +1,83 @@
+package com.kuit.chozy.community.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+        name = "feeds",
+        indexes = {
+                @Index(name = "idx_feeds_user_id", columnList = "user_id"),
+                @Index(name = "idx_feeds_content_type", columnList = "content_type"),
+                @Index(name = "idx_feeds_created_at", columnList = "created_at")
+        }
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Feed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "content_type", nullable = false, length = 20)
+    private FeedContentType contentType;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 5000)
+    private String text;
+
+    @ElementCollection
+    @CollectionTable(name = "feed_images", joinColumns = @JoinColumn(name = "feed_id"))
+    @Column(name = "image_url")
+    @Builder.Default
+    private List<String> contentImgs = new ArrayList<>();
+
+    // REVIEW 타입 전용 (POST 타입은 null)
+    @Column(length = 200)
+    private String vendor;
+
+    @Column(name = "product_url", length = 2048)
+    private String productUrl;
+
+    @Column(length = 500)
+    private String title;
+
+    private Float rating;
+
+    @Column(name = "quote_feed_id")
+    private Long quoteFeedId;
+
+    @Column(name = "comment_count", nullable = false)
+    @Builder.Default
+    private Long commentCount = 0L;
+
+    @Column(name = "like_count", nullable = false)
+    @Builder.Default
+    private Long likeCount = 0L;
+
+    @Column(name = "dislike_count", nullable = false)
+    @Builder.Default
+    private Long dislikeCount = 0L;
+
+    @Column(name = "quote_count", nullable = false)
+    @Builder.Default
+    private Long quoteCount = 0L;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kuit/chozy/community/domain/FeedBookmark.java
+++ b/src/main/java/com/kuit/chozy/community/domain/FeedBookmark.java
@@ -1,0 +1,45 @@
+package com.kuit.chozy.community.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "feed_bookmarks",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_feed_bookmarks_user_feed",
+                        columnNames = {"user_id", "feed_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_feed_bookmarks_user_id", columnList = "user_id"),
+                @Index(name = "idx_feed_bookmarks_feed_id", columnList = "feed_id")
+        }
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FeedBookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "feed_id", nullable = false)
+    private Long feedId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kuit/chozy/community/domain/FeedContentType.java
+++ b/src/main/java/com/kuit/chozy/community/domain/FeedContentType.java
@@ -1,0 +1,6 @@
+package com.kuit.chozy.community.domain;
+
+public enum FeedContentType {
+    POST,
+    REVIEW
+}

--- a/src/main/java/com/kuit/chozy/community/domain/FeedReaction.java
+++ b/src/main/java/com/kuit/chozy/community/domain/FeedReaction.java
@@ -1,0 +1,49 @@
+package com.kuit.chozy.community.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "feed_reactions",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_feed_reactions_user_feed",
+                        columnNames = {"user_id", "feed_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_feed_reactions_user_id", columnList = "user_id"),
+                @Index(name = "idx_feed_reactions_feed_id", columnList = "feed_id")
+        }
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FeedReaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "feed_id", nullable = false)
+    private Long feedId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reaction_type", nullable = false, length = 20)
+    private ReactionType reactionType;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kuit/chozy/community/domain/FeedRepost.java
+++ b/src/main/java/com/kuit/chozy/community/domain/FeedRepost.java
@@ -1,0 +1,43 @@
+package com.kuit.chozy.community.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "feed_reposts",
+        indexes = {
+                @Index(name = "idx_feed_reposts_user_id", columnList = "user_id"),
+                @Index(name = "idx_feed_reposts_source_feed_id", columnList = "source_feed_id"),
+                @Index(name = "idx_feed_reposts_target_feed_id", columnList = "target_feed_id")
+        }
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FeedRepost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "source_feed_id", nullable = false)
+    private Long sourceFeedId;
+
+    @Column(name = "target_feed_id", nullable = false)
+    private Long targetFeedId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kuit/chozy/community/domain/FeedTab.java
+++ b/src/main/java/com/kuit/chozy/community/domain/FeedTab.java
@@ -1,0 +1,6 @@
+package com.kuit.chozy.community.domain;
+
+public enum FeedTab {
+    RECOMMEND,
+    FOLLOWING
+}

--- a/src/main/java/com/kuit/chozy/community/domain/ReactionType.java
+++ b/src/main/java/com/kuit/chozy/community/domain/ReactionType.java
@@ -1,0 +1,7 @@
+package com.kuit.chozy.community.domain;
+
+public enum ReactionType {
+    LIKE,
+    DISLIKE,
+    NONE
+}

--- a/src/main/java/com/kuit/chozy/community/domain/RecentViewedProfile.java
+++ b/src/main/java/com/kuit/chozy/community/domain/RecentViewedProfile.java
@@ -1,4 +1,4 @@
-package com.kuit.chozy.community.entity;
+package com.kuit.chozy.community.domain;
 
 import com.kuit.chozy.user.domain.User;
 import com.kuit.chozy.user.domain.UserStatus;

--- a/src/main/java/com/kuit/chozy/community/dto/response/FeedContentResponse.java
+++ b/src/main/java/com/kuit/chozy/community/dto/response/FeedContentResponse.java
@@ -1,0 +1,27 @@
+package com.kuit.chozy.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedContentResponse {
+    // POST: text, contentImgs
+    private String text;
+    private List<String> contentImgs;
+
+    // REVIEW only
+    private String vendor;
+    private String productUrl;
+    private String title;
+    private Float rating;
+
+    // REVIEW with quote (인용)
+    private FeedQuoteContentResponse quoteContent;
+}

--- a/src/main/java/com/kuit/chozy/community/dto/response/FeedCountsResponse.java
+++ b/src/main/java/com/kuit/chozy/community/dto/response/FeedCountsResponse.java
@@ -1,0 +1,17 @@
+package com.kuit.chozy.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedCountsResponse {
+    private Long commentCount;
+    private Long likeCount;
+    private Long dislikeCount;
+    private Long quoteCount;
+}

--- a/src/main/java/com/kuit/chozy/community/dto/response/FeedItemResponse.java
+++ b/src/main/java/com/kuit/chozy/community/dto/response/FeedItemResponse.java
@@ -1,0 +1,20 @@
+package com.kuit.chozy.community.dto.response;
+
+import com.kuit.chozy.community.domain.FeedContentType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedItemResponse {
+    private Long feedId;
+    private FeedContentType contentType;
+    private FeedUserResponse user;
+    private FeedContentResponse content;
+    private FeedCountsResponse counts;
+    private FeedMyStateResponse myState;
+}

--- a/src/main/java/com/kuit/chozy/community/dto/response/FeedMyStateResponse.java
+++ b/src/main/java/com/kuit/chozy/community/dto/response/FeedMyStateResponse.java
@@ -1,0 +1,17 @@
+package com.kuit.chozy.community.dto.response;
+
+import com.kuit.chozy.community.domain.ReactionType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedMyStateResponse {
+    private ReactionType reaction; // LIKE | DISLIKE | NONE
+    private boolean isBookmarked;
+    private boolean isReposted;
+}

--- a/src/main/java/com/kuit/chozy/community/dto/response/FeedQuoteContentResponse.java
+++ b/src/main/java/com/kuit/chozy/community/dto/response/FeedQuoteContentResponse.java
@@ -1,0 +1,21 @@
+package com.kuit.chozy.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedQuoteContentResponse {
+    private FeedUserResponse user;
+    private String vendor;
+    private String title;
+    private Float rating;
+    private String text;
+    private List<String> contentImgs;
+}

--- a/src/main/java/com/kuit/chozy/community/dto/response/FeedUserResponse.java
+++ b/src/main/java/com/kuit/chozy/community/dto/response/FeedUserResponse.java
@@ -1,0 +1,16 @@
+package com.kuit.chozy.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedUserResponse {
+    private String profileImageUrl;
+    private String name;
+    private String userId; // loginId
+}

--- a/src/main/java/com/kuit/chozy/community/repository/CommunitySearchHistoryRepository.java
+++ b/src/main/java/com/kuit/chozy/community/repository/CommunitySearchHistoryRepository.java
@@ -1,7 +1,6 @@
 package com.kuit.chozy.community.repository;
 
-import com.kuit.chozy.community.entity.CommunitySearchHistory;
-import com.kuit.chozy.home.entity.SearchHistory;
+import com.kuit.chozy.community.domain.CommunitySearchHistory;
 import com.kuit.chozy.home.entity.SearchStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/kuit/chozy/community/repository/FeedBookmarkRepository.java
+++ b/src/main/java/com/kuit/chozy/community/repository/FeedBookmarkRepository.java
@@ -1,0 +1,11 @@
+package com.kuit.chozy.community.repository;
+
+import com.kuit.chozy.community.domain.FeedBookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FeedBookmarkRepository extends JpaRepository<FeedBookmark, Long> {
+
+    List<FeedBookmark> findByUserIdAndFeedIdIn(Long userId, List<Long> feedIds);
+}

--- a/src/main/java/com/kuit/chozy/community/repository/FeedReactionRepository.java
+++ b/src/main/java/com/kuit/chozy/community/repository/FeedReactionRepository.java
@@ -1,0 +1,16 @@
+package com.kuit.chozy.community.repository;
+
+import com.kuit.chozy.community.domain.FeedReaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FeedReactionRepository extends JpaRepository<FeedReaction, Long> {
+
+    Optional<FeedReaction> findByUserIdAndFeedId(Long userId, Long feedId);
+
+    List<FeedReaction> findByUserIdAndFeedIdIn(Long userId, List<Long> feedIds);
+
+    boolean existsByUserIdAndFeedId(Long userId, Long feedId);
+}

--- a/src/main/java/com/kuit/chozy/community/repository/FeedRepository.java
+++ b/src/main/java/com/kuit/chozy/community/repository/FeedRepository.java
@@ -1,0 +1,52 @@
+package com.kuit.chozy.community.repository;
+
+import com.kuit.chozy.community.domain.Feed;
+import com.kuit.chozy.community.domain.FeedContentType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+
+    Page<Feed> findByContentTypeOrderByCreatedAtDesc(FeedContentType contentType, Pageable pageable);
+
+    Page<Feed> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Page<Feed> findByUserIdInOrderByCreatedAtDesc(List<Long> userIds, Pageable pageable);
+
+    Page<Feed> findByUserIdInAndContentTypeOrderByCreatedAtDesc(List<Long> userIds, FeedContentType contentType, Pageable pageable);
+
+    @Query("""
+        SELECT f FROM Feed f
+        WHERE (:contentType IS NULL OR f.contentType = :contentType)
+        AND (LOWER(f.text) LIKE LOWER(CONCAT('%', :search, '%'))
+             OR LOWER(f.title) LIKE LOWER(CONCAT('%', :search, '%'))
+             OR LOWER(f.vendor) LIKE LOWER(CONCAT('%', :search, '%')))
+        ORDER BY f.createdAt DESC
+        """)
+    Page<Feed> findBySearchOrderByCreatedAtDesc(
+            @Param("search") String search,
+            @Param("contentType") FeedContentType contentType,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT f FROM Feed f
+        WHERE f.userId IN :userIds
+        AND (:contentType IS NULL OR f.contentType = :contentType)
+        AND (LOWER(f.text) LIKE LOWER(CONCAT('%', :search, '%'))
+             OR LOWER(f.title) LIKE LOWER(CONCAT('%', :search, '%'))
+             OR LOWER(f.vendor) LIKE LOWER(CONCAT('%', :search, '%')))
+        ORDER BY f.createdAt DESC
+        """)
+    Page<Feed> findByUserIdInAndSearchOrderByCreatedAtDesc(
+            @Param("userIds") List<Long> userIds,
+            @Param("search") String search,
+            @Param("contentType") FeedContentType contentType,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/kuit/chozy/community/repository/FeedRepostRepository.java
+++ b/src/main/java/com/kuit/chozy/community/repository/FeedRepostRepository.java
@@ -1,0 +1,15 @@
+package com.kuit.chozy.community.repository;
+
+import com.kuit.chozy.community.domain.FeedRepost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FeedRepostRepository extends JpaRepository<FeedRepost, Long> {
+
+    List<FeedRepost> findByUserIdAndSourceFeedIdIn(Long userId, List<Long> sourceFeedIds);
+
+    boolean existsByUserIdAndSourceFeedId(Long userId, Long sourceFeedId);
+
+    List<FeedRepost> findByTargetFeedIdIn(List<Long> targetFeedIds);
+}

--- a/src/main/java/com/kuit/chozy/community/repository/RecentViewedProfileRepository.java
+++ b/src/main/java/com/kuit/chozy/community/repository/RecentViewedProfileRepository.java
@@ -1,6 +1,6 @@
 package com.kuit.chozy.community.repository;
 
-import com.kuit.chozy.community.entity.RecentViewedProfile;
+import com.kuit.chozy.community.domain.RecentViewedProfile;
 import com.kuit.chozy.user.domain.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/kuit/chozy/community/service/CommunityFeedService.java
+++ b/src/main/java/com/kuit/chozy/community/service/CommunityFeedService.java
@@ -1,0 +1,196 @@
+package com.kuit.chozy.community.service;
+
+import com.kuit.chozy.community.dto.response.*;
+import com.kuit.chozy.community.domain.*;
+import com.kuit.chozy.community.repository.FeedBookmarkRepository;
+import com.kuit.chozy.community.repository.FeedReactionRepository;
+import com.kuit.chozy.community.repository.FeedRepostRepository;
+import com.kuit.chozy.community.repository.FeedRepository;
+import com.kuit.chozy.user.domain.User;
+import com.kuit.chozy.user.repository.UserRepository;
+import com.kuit.chozy.userrelation.repository.FollowRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommunityFeedService {
+
+    private static final int MAX_PAGE_SIZE = 50;
+
+    private final FeedRepository feedRepository;
+    private final FeedReactionRepository feedReactionRepository;
+    private final FeedRepostRepository feedRepostRepository;
+    private final FeedBookmarkRepository feedBookmarkRepository;
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+
+    public List<FeedItemResponse> getFeeds(
+            Long userId,
+            FeedTab tab,
+            String contentTypeParam,
+            String search,
+            int page,
+            int size
+    ) {
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        FeedContentType contentType = parseContentType(contentTypeParam);
+        List<Feed> feeds;
+
+        if (StringUtils.hasText(search)) {
+            feeds = getFeedsBySearch(search.trim(), tab, contentType, userId, pageable);
+        } else {
+            feeds = getFeedsWithoutSearch(tab, contentType, userId, pageable);
+        }
+
+        if (feeds.isEmpty()) {
+            return List.of();
+        }
+
+        return buildFeedItemResponses(feeds, userId);
+    }
+
+    private FeedContentType parseContentType(String contentTypeParam) {
+        if (contentTypeParam == null || "ALL".equalsIgnoreCase(contentTypeParam)) {
+            return null;
+        }
+        return FeedContentType.valueOf(contentTypeParam.toUpperCase());
+    }
+
+    private List<Feed> getFeedsWithoutSearch(FeedTab tab, FeedContentType contentType, Long userId, Pageable pageable) {
+        if (tab == FeedTab.FOLLOWING) {
+            List<Long> followingUserIds = followRepository.findByFollowerId(userId, Pageable.unpaged())
+                    .getContent().stream()
+                    .map(f -> f.getFollowingId())
+                    .toList();
+            if (followingUserIds.isEmpty()) {
+                return List.of();
+            }
+            if (contentType == null) {
+                return feedRepository.findByUserIdInOrderByCreatedAtDesc(followingUserIds, pageable).getContent();
+            }
+            return feedRepository.findByUserIdInAndContentTypeOrderByCreatedAtDesc(followingUserIds, contentType, pageable).getContent();
+        } else {
+            if (contentType == null) {
+                return feedRepository.findAllByOrderByCreatedAtDesc(pageable).getContent();
+            }
+            return feedRepository.findByContentTypeOrderByCreatedAtDesc(contentType, pageable).getContent();
+        }
+    }
+
+    private List<Feed> getFeedsBySearch(String search, FeedTab tab, FeedContentType contentType, Long userId, Pageable pageable) {
+        if (tab == FeedTab.FOLLOWING) {
+            List<Long> followingUserIds = followRepository.findByFollowerId(userId, Pageable.unpaged())
+                    .getContent().stream()
+                    .map(f -> f.getFollowingId())
+                    .toList();
+            if (followingUserIds.isEmpty()) {
+                return List.of();
+            }
+            return feedRepository.findByUserIdInAndSearchOrderByCreatedAtDesc(followingUserIds, search, contentType, pageable).getContent();
+        } else {
+            return feedRepository.findBySearchOrderByCreatedAtDesc(search, contentType, pageable).getContent();
+        }
+    }
+
+    private List<FeedItemResponse> buildFeedItemResponses(List<Feed> feeds, Long currentUserId) {
+        List<Long> feedIds = feeds.stream().map(Feed::getId).toList();
+        Set<Long> authorIds = feeds.stream().map(Feed::getUserId).collect(Collectors.toSet());
+        Map<Long, User> userMap = userRepository.findByIdIn(new ArrayList<>(authorIds)).stream()
+                .collect(Collectors.toMap(User::getId, u -> u));
+
+        Map<Long, FeedReaction> reactionMap = feedReactionRepository.findByUserIdAndFeedIdIn(currentUserId, feedIds).stream()
+                .collect(Collectors.toMap(FeedReaction::getFeedId, r -> r));
+        Set<Long> repostedFeedIds = feedRepostRepository.findByUserIdAndSourceFeedIdIn(currentUserId, feedIds).stream()
+                .map(FeedRepost::getSourceFeedId).collect(Collectors.toSet());
+        Set<Long> bookmarkedFeedIds = feedBookmarkRepository.findByUserIdAndFeedIdIn(currentUserId, feedIds).stream()
+                .map(FeedBookmark::getFeedId).collect(Collectors.toSet());
+
+        Set<Long> quoteFeedIds = feeds.stream().map(Feed::getQuoteFeedId).filter(Objects::nonNull).collect(Collectors.toSet());
+        Map<Long, Feed> quoteFeedMap = quoteFeedIds.isEmpty() ? Map.of()
+                : feedRepository.findAllById(quoteFeedIds).stream().collect(Collectors.toMap(Feed::getId, f -> f));
+        Set<Long> quoteAuthorIds = quoteFeedMap.values().stream().map(Feed::getUserId).collect(Collectors.toSet());
+        Map<Long, User> quoteUserMap = quoteAuthorIds.isEmpty() ? Map.of()
+                : userRepository.findByIdIn(new ArrayList<>(quoteAuthorIds)).stream().collect(Collectors.toMap(User::getId, u -> u));
+
+        List<FeedItemResponse> result = new ArrayList<>();
+        for (Feed feed : feeds) {
+            User author = userMap.get(feed.getUserId());
+            FeedUserResponse userResponse = toFeedUserResponse(author);
+
+            FeedContentResponse contentResponse = FeedContentResponse.builder()
+                    .text(feed.getText())
+                    .contentImgs(feed.getContentImgs() != null ? feed.getContentImgs() : List.of())
+                    .vendor(feed.getVendor())
+                    .productUrl(feed.getProductUrl())
+                    .title(feed.getTitle())
+                    .rating(feed.getRating())
+                    .quoteContent(feed.getQuoteFeedId() != null ? buildQuoteContentResponse(quoteFeedMap.get(feed.getQuoteFeedId()), quoteUserMap) : null)
+                    .build();
+
+            FeedCountsResponse countsResponse = FeedCountsResponse.builder()
+                    .commentCount(feed.getCommentCount())
+                    .likeCount(feed.getLikeCount())
+                    .dislikeCount(feed.getDislikeCount())
+                    .quoteCount(feed.getQuoteCount())
+                    .build();
+
+            FeedReaction reaction = reactionMap.get(feed.getId());
+            ReactionType reactionType = reaction != null ? reaction.getReactionType() : ReactionType.NONE;
+            FeedMyStateResponse myState = FeedMyStateResponse.builder()
+                    .reaction(reactionType)
+                    .isBookmarked(bookmarkedFeedIds.contains(feed.getId()))
+                    .isReposted(repostedFeedIds.contains(feed.getId()))
+                    .build();
+
+            result.add(FeedItemResponse.builder()
+                    .feedId(feed.getId())
+                    .contentType(feed.getContentType())
+                    .user(userResponse)
+                    .content(contentResponse)
+                    .counts(countsResponse)
+                    .myState(myState)
+                    .build());
+        }
+        return result;
+    }
+
+    private FeedUserResponse toFeedUserResponse(User user) {
+        if (user == null) {
+            return FeedUserResponse.builder()
+                    .userId("")
+                    .name("")
+                    .profileImageUrl(null)
+                    .build();
+        }
+        return FeedUserResponse.builder()
+                .profileImageUrl(user.getProfileImageUrl())
+                .name(user.getNickname() != null ? user.getNickname() : user.getName())
+                .userId(user.getLoginId())
+                .build();
+    }
+
+    private FeedQuoteContentResponse buildQuoteContentResponse(Feed quoteFeed, Map<Long, User> userMap) {
+        if (quoteFeed == null) return null;
+        User quoteUser = userMap.get(quoteFeed.getUserId());
+        return FeedQuoteContentResponse.builder()
+                .user(toFeedUserResponse(quoteUser))
+                .vendor(quoteFeed.getVendor())
+                .title(quoteFeed.getTitle())
+                .rating(quoteFeed.getRating())
+                .text(quoteFeed.getText())
+                .contentImgs(quoteFeed.getContentImgs() != null ? quoteFeed.getContentImgs() : List.of())
+                .build();
+    }
+}

--- a/src/main/java/com/kuit/chozy/community/service/CommunitySearchService.java
+++ b/src/main/java/com/kuit/chozy/community/service/CommunitySearchService.java
@@ -2,8 +2,8 @@ package com.kuit.chozy.community.service;
 
 import com.kuit.chozy.community.dto.response.RecentViewedProfileResponse;
 import com.kuit.chozy.community.dto.response.UserLoginIdRecommendResponse;
-import com.kuit.chozy.community.entity.CommunitySearchHistory;
-import com.kuit.chozy.community.entity.RecentViewedProfile;
+import com.kuit.chozy.community.domain.CommunitySearchHistory;
+import com.kuit.chozy.community.domain.RecentViewedProfile;
 import com.kuit.chozy.community.repository.CommunitySearchHistoryRepository;
 import com.kuit.chozy.community.repository.CommunityUserRepository;
 import com.kuit.chozy.community.repository.RecentViewedProfileRepository;

--- a/src/main/java/com/kuit/chozy/post/repository/PostRepository.java
+++ b/src/main/java/com/kuit/chozy/post/repository/PostRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
     
-    @Query("SELECT p FROM Post p WHERE p.userId = :userId AND p.content LIKE %:keyword% ORDER BY p.createdAt DESC")
+    @Query("SELECT p FROM Post p WHERE p.userId = :userId AND p.content LIKE CONCAT('%', :keyword, '%') ORDER BY p.createdAt DESC")
     Page<Post> findByUserIdAndContentContainingOrderByCreatedAtDesc(
             @Param("userId") Long userId,
             @Param("keyword") String keyword,


### PR DESCRIPTION
## 🌠 관련 이슈
#15 

## 🌠 주요 변경 사항
- Feed, FeedBookmark, FeedReaction, FeedRepost 등 domain 추가
- CommunityFeedController 추가
- CommunityFeedService 추가
- 탭, 컨텐츠 타입, 검색어, 페이지 조건에 맞는 Feed 목록 가져오기 기능 추가

## 🌠 기타 작업
- Feed 관련 DTO 추가
- Feed 관련 repository 추가
- ContentType, FeedTab, ReactionType ENUM 추가


## 🌠 미구현된 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 커뮤니티 피드 조회 기능 추가 - 추천/팔로잉 탭과 콘텐츠 타입(포스트/리뷰)으로 필터링 가능
  * 피드 검색 기능 추가 - 텍스트, 제목, 판매처 정보로 검색 가능
  * 페이지네이션 지원 - 피드 목록을 페이지 단위로 조회
  * 피드 상호작용 기능 추가 - 좋아요/싫어요 반응, 북마크, 리포스트 기능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->