### PR TITLE
[Feat] 카카오 로그인 온보딩 입력

### DIFF
--- a/src/main/java/com/kuit/chozy/user/service/UserOnboardingService.java
+++ b/src/main/java/com/kuit/chozy/user/service/UserOnboardingService.java
@@ -51,8 +51,15 @@ public class UserOnboardingService {
     }
 
     private void validateNickname(String nickname) {
-        /* 한글만 가능 (예: 1~10자). 필요하면 길이 조정 */
-        if (!nickname.matches("^[가-힣]{1,10}$")) {
+        if (nickname == null) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST);
+        }
+
+        if (nickname.length() > 8) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST);
+        }
+
+        if (!nickname.matches("^[가-힣 ]*$")) {
             throw new ApiException(ErrorCode.INVALID_REQUEST);
         }
     }


### PR DESCRIPTION
## 🌠 관련 이슈
#29 

## 🌠 주요 변경 사항
- 카카오 로그인 성공 후, needsOnboarding=true인 사용자에게 닉네임을 입력받는 기능을 구현

## 🌠 기타 작업

## 🌠 미구현된 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 닉네임 검증 규칙이 업데이트되었습니다. 닉네임의 최대 길이가 8글자로 제한되었으며, 한글 문자와 공백만 입력할 수 있습니다. 유효하지 않은 형식에 대한 오류 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->