### PR TITLE
[Refactor] 타깃 Id 팔로잉/팔로워 목록 조회

### DIFF
--- a/src/main/java/com/kuit/chozy/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kuit/chozy/global/common/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     FEED_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, 4035, "본인 게시글만 수정할 수 있습니다."),
     FOLLOW_REQUEST_FORBIDDEN(HttpStatus.FORBIDDEN, 4032, "해당 팔로우 요청을 처리할 권한이 없습니다."),
     REVIEW_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, 4034, "리뷰 작성자만 수정할 수 있습니다."),
+    PRIVATE_ACCOUNT_FORBIDDEN(HttpStatus.FORBIDDEN, 4036, "비공개 계정의 팔로우 목록은 접근할 수 없습니다."),
 
     // ================= 404 =================
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 4040, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/kuit/chozy/userrelation/controller/FollowController.java
+++ b/src/main/java/com/kuit/chozy/userrelation/controller/FollowController.java
@@ -40,21 +40,47 @@ public class FollowController {
 
     // 팔로워 목록 조회
     @GetMapping("/me/followers")
-    public ApiResponse<FollowerListResponse> getFollowers(
+    public ApiResponse<FollowerListResponse> getMyFollowers(
             @UserId Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
-        return ApiResponse.success(followListService.getFollowers(userId, page, size));
+        return ApiResponse.success(
+                followListService.getFollowers(userId, userId, page, size)
+        );
     }
 
     // 팔로잉 목록 조회
     @GetMapping("/me/followings")
-    public ApiResponse<FollowingListResponse> getFollowings(
+    public ApiResponse<FollowingListResponse> getMyFollowings(
             @UserId Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
-        return ApiResponse.success(followListService.getFollowings(userId, page, size));
+        return ApiResponse.success(
+                followListService.getFollowings(userId, userId, page, size)
+        );
+    }
+
+
+    // 타깃 팔로워/팔로잉 목록 조회
+    @GetMapping("/{targetUserId}/followers")
+    public ApiResponse<FollowerListResponse> getUserFollowers(
+            @UserId Long viewerId,
+            @PathVariable Long targetUserId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ApiResponse.success(followListService.getFollowers(viewerId, targetUserId, page, size));
+    }
+
+    @GetMapping("/{targetUserId}/followings")
+    public ApiResponse<FollowingListResponse> getUserFollowings(
+            @UserId Long viewerId,
+            @PathVariable Long targetUserId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ApiResponse.success(followListService.getFollowings(viewerId, targetUserId, page, size));
     }
 }


### PR DESCRIPTION
## 🌠 관련 이슈

## 🌠 주요 변경 사항
- 타깃 아이디 기준 팔로잉/팔로워 목록 조회

## 🌠 기타 작업

## 🌠 미구현된 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 다른 사용자의 팔로워 및 팔로잉 목록 조회 기능 추가
  * 비공개 계정의 팔로우 목록에 대한 접근 권한 제어 추가 (본인 또는 팔로워만 접근 가능)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->