### PR TITLE
[Fix] 게시글 조회 시 userId 불필요한 경우 분기

### DIFF
--- a/src/main/java/com/kuit/chozy/community/controller/CommunityFeedController.java
+++ b/src/main/java/com/kuit/chozy/community/controller/CommunityFeedController.java
@@ -6,6 +6,7 @@ import com.kuit.chozy.community.dto.response.FeedDetailResponse;
 import com.kuit.chozy.community.dto.response.FeedListResultResponse;
 import com.kuit.chozy.community.domain.FeedTab;
 import com.kuit.chozy.community.service.CommunityFeedService;
+import com.kuit.chozy.global.common.auth.OptionalUserId;
 import com.kuit.chozy.global.common.auth.UserId;
 import com.kuit.chozy.global.common.exception.ApiException;
 import com.kuit.chozy.global.common.exception.ErrorCode;
@@ -33,7 +34,7 @@ public class CommunityFeedController {
      */
     @GetMapping
     public ApiResponse<FeedListResultResponse> getFeeds(
-            @UserId Long userId,
+            @OptionalUserId Long userId,
             @RequestParam(defaultValue = "RECOMMEND") FeedTab tab,
             @RequestParam(defaultValue = "ALL") String contentType,
             @RequestParam(required = false) String search,
@@ -49,7 +50,7 @@ public class CommunityFeedController {
      */
     @GetMapping("/{feedId}/detail")
     public ApiResponse<FeedDetailResponse> getFeedDetail(
-            @UserId Long userId,
+            @OptionalUserId Long userId,
             @PathVariable Long feedId
     ) {
         FeedDetailResponse result = communityFeedService.getFeedDetail(feedId, userId);

--- a/src/main/java/com/kuit/chozy/global/common/auth/OptionalUserId.java
+++ b/src/main/java/com/kuit/chozy/global/common/auth/OptionalUserId.java
@@ -1,0 +1,14 @@
+package com.kuit.chozy.global.common.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface OptionalUserId {
+}
+

--- a/src/main/java/com/kuit/chozy/global/common/auth/OptionalUserIdArgumentResolver.java
+++ b/src/main/java/com/kuit/chozy/global/common/auth/OptionalUserIdArgumentResolver.java
@@ -1,0 +1,58 @@
+package com.kuit.chozy.global.common.auth;
+
+import com.kuit.chozy.global.common.exception.ApiException;
+import com.kuit.chozy.global.common.exception.ErrorCode;
+import com.kuit.chozy.global.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class OptionalUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(OptionalUserId.class)
+                && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        String authHeader = webRequest.getHeader("Authorization");
+
+        // 헤더가 없거나 비어 있으면 비로그인으로 간주
+        if (authHeader == null || authHeader.isBlank()) {
+            return null;
+        }
+
+        if (!authHeader.startsWith("Bearer ")) {
+            throw new ApiException(ErrorCode.UNAUTHORIZED);
+        }
+
+        String token = extractBearerToken(authHeader);
+        return jwtUtil.getUserId(token);
+    }
+
+    private String extractBearerToken(String header) {
+        String prefix = "Bearer ";
+
+        if (!header.startsWith(prefix)) {
+            throw new ApiException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return header.substring(prefix.length()).trim();
+    }
+}
+

--- a/src/main/java/com/kuit/chozy/global/common/config/WebMvcConfig.java
+++ b/src/main/java/com/kuit/chozy/global/common/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package com.kuit.chozy.global.common.config;
 
+import com.kuit.chozy.global.common.auth.OptionalUserIdArgumentResolver;
 import com.kuit.chozy.global.common.auth.UserIdArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import java.util.List;
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final UserIdArgumentResolver userIdArgumentResolver;
+    private final OptionalUserIdArgumentResolver optionalUserIdArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -32,5 +34,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(userIdArgumentResolver);
+        resolvers.add(optionalUserIdArgumentResolver);
     }
 }
+


### PR DESCRIPTION
## 🌠 관련 이슈
- #31 

## 🌠 주요 변경 사항
- OptionalUserId ArgumentResolver 추가
- 게시글 조회, 상세 조회 시 userId 없는 케이스 추가 

## 🌠 기타 작업
- CommunityFeedController / Service 수정

## 🌠 미구현된 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 비로그인 사용자도 커뮤니티 피드 및 피드 상세 정보를 조회할 수 있도록 개선했습니다. 익명 사용자의 경우 팔로우 정보, 반응, 북마크, 재공유 상태 등 사용자별 데이터는 기본값으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->