### PR TITLE
[Fix] OriginalFeed 정보 repost/quote 동일하게 적용

### DIFF
--- a/src/main/java/com/kuit/chozy/community/dto/response/FeedDetailContentResponse.java
+++ b/src/main/java/com/kuit/chozy/community/dto/response/FeedDetailContentResponse.java
@@ -23,4 +23,5 @@ public class FeedDetailContentResponse {
     private String content;
     private List<FeedImageItemResponse> feedImages;
     private List<String> hashTags;
+    private FeedQuoteInContentResponse quote;  // kind=QUOTE, REPOST일 때 존재
 }

--- a/src/main/java/com/kuit/chozy/community/dto/response/FeedListContentResponse.java
+++ b/src/main/java/com/kuit/chozy/community/dto/response/FeedListContentResponse.java
@@ -15,5 +15,5 @@ public class FeedListContentResponse {
     private String text;
     private List<FeedImageItemResponse> images;
     private FeedReviewInContentResponse review;  // contentType=REVIEW일 때만
-    private FeedQuoteInContentResponse quote;    // kind=QUOTE일 때만
+    private FeedQuoteInContentResponse quote;    // kind=QUOTE, REPOST일 때 존재
 }


### PR DESCRIPTION
## 🌠 관련 이슈
- #15 
- #31 

## 🌠 주요 변경 사항
- 게시글 조회 시 quote 정보 (OriginalFeed) repost/quote 모두 적용

## 🌠 기타 작업

## 🌠 미구현된 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 인용된 게시물과 리포스트된 게시물에서 원본 게시물의 정보를 피드 목록 및 상세 뷰에서 확인할 수 있습니다. 인용과 리포스트된 콘텐츠의 원본 데이터가 일관되게 표시되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->