### PR TITLE
[Fix] Block 목록 조회 로직 수정

### DIFF
--- a/src/main/java/com/kuit/chozy/userrelation/repository/FollowRepository.java
+++ b/src/main/java/com/kuit/chozy/userrelation/repository/FollowRepository.java
@@ -30,6 +30,25 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
 
+    List<Follow> findByFollowerIdAndFollowingIdInAndStatus(
+            Long followerId,
+            List<Long> followingIds,
+            FollowStatus status
+    );
+
+    List<Follow> findByFollowerIdInAndFollowingIdAndStatus(
+            List<Long> followerIds,
+            Long followingId,
+            FollowStatus status
+    );
+
+    boolean existsByFollowerIdAndFollowingIdAndStatus(
+            Long followerId,
+            Long followingId,
+            FollowStatus status
+    );
+
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         update Follow f

--- a/src/main/java/com/kuit/chozy/userrelation/service/BlockService.java
+++ b/src/main/java/com/kuit/chozy/userrelation/service/BlockService.java
@@ -112,7 +112,7 @@ public class BlockService {
                 .collect(Collectors.toMap(User::getId, Function.identity()));
 
         Set<Long> myFollowingSet = followRepository
-                .findByFollowerIdAndFollowingIdIn(userId, blockedIds)
+                .findByFollowerIdAndFollowingIdInAndStatus(userId, blockedIds, FollowStatus.FOLLOWING)
                 .stream()
                 .map(Follow::getFollowingId)
                 .collect(Collectors.toSet());
@@ -124,7 +124,7 @@ public class BlockService {
                 .collect(Collectors.toSet());
 
         Set<Long> followingMeSet = followRepository
-                .findByFollowerIdInAndFollowingId(blockedIds, userId)
+                .findByFollowerIdInAndFollowingIdAndStatus(blockedIds, userId, FollowStatus.FOLLOWING)
                 .stream()
                 .map(Follow::getFollowerId)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/kuit/chozy/userrelation/service/FollowListService.java
+++ b/src/main/java/com/kuit/chozy/userrelation/service/FollowListService.java
@@ -266,7 +266,11 @@ public class FollowListService {
             return;
         }
 
-        boolean isFollower = followRepository.existsByFollowerIdAndFollowingId(viewerId, target.getId());
+        boolean isFollower = followRepository.existsByFollowerIdAndFollowingIdAndStatus(
+                viewerId,
+                target.getId(),
+                FollowStatus.FOLLOWING
+        );
         if (isFollower) {
             return;
         }

--- a/src/main/java/com/kuit/chozy/userrelation/service/FollowService.java
+++ b/src/main/java/com/kuit/chozy/userrelation/service/FollowService.java
@@ -67,7 +67,13 @@ public class FollowService {
             throw new ApiException(ErrorCode.CANNOT_FOLLOW_BLOCKED_USER);
         }
 
-        if (followRepository.existsByFollowerIdAndFollowingId(userId, targetUserId)) {
+        boolean alreadyFollowing = followRepository.existsByFollowerIdAndFollowingIdAndStatus(
+                userId,
+                targetUserId,
+                FollowStatus.FOLLOWING
+        );
+
+        if (alreadyFollowing) {
             throw new ApiException(ErrorCode.ALREADY_FOLLOWING);
         }
 


### PR DESCRIPTION
## 🌠 관련 이슈

## 🌠 주요 변경 사항
- 팔로잉 중 블락 관련 로직 수정

## 🌠 기타 작업

## 🌠 미구현된 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 팔로우 관계 확인 시 팔로우 상태를 정확히 구분하여 처리하도록 개선하였습니다.
  * 차단된 사용자 조회, 팔로우 목록 접근 권한 검증, 팔로우 중복 확인 등의 기능에서 활성 팔로우 관계만 반영되도록 수정하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->