### PR TITLE
[Feat] 게시글 조회 시 내가 차단한 사용자, 나를 차단한 사용자 양측 전부 block

### DIFF
--- a/src/main/java/com/kuit/chozy/community/service/CommunityFeedService.java
+++ b/src/main/java/com/kuit/chozy/community/service/CommunityFeedService.java
@@ -125,23 +125,29 @@ public class CommunityFeedService {
             if (followingUserIds.isEmpty()) return List.of();
 
             List<Long> mutedIds = muteRepository.findMutedIdsByMuterIdAndActiveTrue(userId);
+            List<Long> blockedIds = blockRepository.findBlockedIdsByBlockerIdAndActiveTrue(userId);
             List<Long> allowedFollowing = followingUserIds.stream()
-                    .filter(id -> !mutedIds.contains(id))
+                    .filter(id -> !mutedIds.contains(id) && !blockedIds.contains(id))
                     .toList();
             if (allowedFollowing.isEmpty()) return List.of();
 
             List<Long> blockerIds = blockRepository.findBlockerIdsByBlockedIdAndActiveTrue(userId);
-            if (blockerIds.isEmpty()) {
+            Set<Long> blockExcludeSet = new HashSet<>(blockerIds);
+            blockExcludeSet.addAll(blockedIds);
+            if (blockExcludeSet.isEmpty()) {
                 return feedRepository.findForFollowingCursor(allowedFollowing, cursorId, contentType, pageable);
             }
-            return feedRepository.findForFollowingCursorExcluding(allowedFollowing, blockerIds, cursorId, contentType, pageable);
+            List<Long> blockExcludeList = new ArrayList<>(blockExcludeSet);
+            return feedRepository.findForFollowingCursorExcluding(allowedFollowing, blockExcludeList, cursorId, contentType, pageable);
         }
 
-        // RECOMMEND: 로그인 시 나를 차단한 사람 + 내가 관심없음한 사람 게시물 제외
+        // RECOMMEND: 로그인 시 나를 차단한 사람 + 내가 차단한 사람 + 내가 관심없음한 사람 게시물 제외
         if (userId != null) {
             List<Long> blockerIds = blockRepository.findBlockerIdsByBlockedIdAndActiveTrue(userId);
+            List<Long> blockedIds = blockRepository.findBlockedIdsByBlockerIdAndActiveTrue(userId);
             List<Long> mutedIds = muteRepository.findMutedIdsByMuterIdAndActiveTrue(userId);
             Set<Long> excludeSet = new HashSet<>(blockerIds);
+            excludeSet.addAll(blockedIds);
             excludeSet.addAll(mutedIds);
             if (!excludeSet.isEmpty()) {
                 List<Long> excludeUserIds = new ArrayList<>(excludeSet);
@@ -163,22 +169,28 @@ public class CommunityFeedService {
             if (followingUserIds.isEmpty()) return List.of();
 
             List<Long> mutedIds = muteRepository.findMutedIdsByMuterIdAndActiveTrue(userId);
+            List<Long> blockedIds = blockRepository.findBlockedIdsByBlockerIdAndActiveTrue(userId);
             List<Long> allowedFollowing = followingUserIds.stream()
-                    .filter(id -> !mutedIds.contains(id))
+                    .filter(id -> !mutedIds.contains(id) && !blockedIds.contains(id))
                     .toList();
             if (allowedFollowing.isEmpty()) return List.of();
 
             List<Long> blockerIds = blockRepository.findBlockerIdsByBlockedIdAndActiveTrue(userId);
-            if (blockerIds.isEmpty()) {
+            Set<Long> blockExcludeSet = new HashSet<>(blockerIds);
+            blockExcludeSet.addAll(blockedIds);
+            if (blockExcludeSet.isEmpty()) {
                 return feedRepository.findForFollowingCursorWithSearch(allowedFollowing, cursorId, contentType, search, pageable);
             }
-            return feedRepository.findForFollowingCursorWithSearchExcluding(allowedFollowing, blockerIds, cursorId, contentType, search, pageable);
+            List<Long> blockExcludeList = new ArrayList<>(blockExcludeSet);
+            return feedRepository.findForFollowingCursorWithSearchExcluding(allowedFollowing, blockExcludeList, cursorId, contentType, search, pageable);
         }
 
         if (userId != null) {
             List<Long> blockerIds = blockRepository.findBlockerIdsByBlockedIdAndActiveTrue(userId);
+            List<Long> blockedIds = blockRepository.findBlockedIdsByBlockerIdAndActiveTrue(userId);
             List<Long> mutedIds = muteRepository.findMutedIdsByMuterIdAndActiveTrue(userId);
             Set<Long> excludeSet = new HashSet<>(blockerIds);
+            excludeSet.addAll(blockedIds);
             excludeSet.addAll(mutedIds);
             if (!excludeSet.isEmpty()) {
                 List<Long> excludeUserIds = new ArrayList<>(excludeSet);

--- a/src/main/java/com/kuit/chozy/userrelation/repository/BlockRepository.java
+++ b/src/main/java/com/kuit/chozy/userrelation/repository/BlockRepository.java
@@ -17,6 +17,10 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     @Query("SELECT b.blockerId FROM Block b WHERE b.blockedId = :blockedId AND b.active = true")
     List<Long> findBlockerIdsByBlockedIdAndActiveTrue(@Param("blockedId") Long blockedId);
 
+    /** 내가 차단한 사람(blocked)의 ID 목록. 이 사람들의 게시물은 내 피드에 노출하지 않음. */
+    @Query("SELECT b.blockedId FROM Block b WHERE b.blockerId = :blockerId AND b.active = true")
+    List<Long> findBlockedIdsByBlockerIdAndActiveTrue(@Param("blockerId") Long blockerId);
+
     Optional<Block> findByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
 
     Optional<Block> findByBlockerIdAndBlockedIdAndActiveTrue(Long blockerId, Long blockedId);


### PR DESCRIPTION
## 🌠 관련 이슈
- #84 

## 🌠 주요 변경 사항
- 나를 차단한 사용자, 내가 차단한 사용자의 게시글 전부 제외

## 🌠 기타 작업

## 🌠 미구현된 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 차단한 사용자 및 자신을 차단한 사용자가 피드에서 올바르게 제외됩니다.
  * 팔로우 피드, 검색 결과, 추천 사항에서 차단 관계가 더 정확하게 적용됩니다.
  * 뮤트된 사용자와 함께 차단된 사용자도 피드 필터링에 포함되어 더 나은 콘텐츠 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->